### PR TITLE
Update state from storage

### DIFF
--- a/src/Main.ts
+++ b/src/Main.ts
@@ -11,5 +11,6 @@ export type Scenarios = {
 }
 
 export type Ports = Elm.Ports<{
+    loadScenarios: Elm.IncomingPort<Scenarios>
     storeScenarios: Elm.OutgoingPort<Scenarios>
 }>

--- a/src/Ports.elm
+++ b/src/Ports.elm
@@ -1,6 +1,9 @@
-port module Ports exposing (storeScenarios)
+port module Ports exposing (loadScenarios, storeScenarios)
 
 import Json.Encode as Encode
 
 
 port storeScenarios : Encode.Value -> Cmd msg
+
+
+port loadScenarios : (Encode.Value -> msg) -> Sub msg

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,4 +12,13 @@ app.ports.storeScenarios.subscribe(todo => {
     localStorage.setItem('scenario-save', JSON.stringify(todo));
 });
 
+window.addEventListener('storage', () => {
+    try {
+        const todo = window.localStorage.getItem('scenario-save')
+        app.ports.loadScenarios.send(JSON.parse(todo))
+    } catch (e) {
+        console.error(e);
+    }
+});
+
 document.body.addEventListener('touchstart', function () { }, false);


### PR DESCRIPTION
If #SlingMountain is open in multiple windows then local storage updates to which ever the last one was that changed. This patch will keep the completed and disabled lists in sync, and only updates the current item if it is completed or disabled in local storage.