### PR TITLE
Fail when elm-tailwind-modules needs updating

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -97,4 +97,5 @@ jobs:
         if: steps.changes.outputs.changed == 1
         run: |
           echo "::error::Unstaged changes detected - it is likely that the Elm Tailwind Modules need updating."
+          git status --porcelain
           exit 1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -95,4 +95,6 @@ jobs:
         run: echo "changed=$(git status --porcelain | wc -l)" >> $GITHUB_OUTPUT
       - name: Report changes
         if: steps.changes.outputs.changed == 1
-        run: echo "::error::Unstaged changes detected - it is likely that the Elm Tailwind Modules need updating."
+        run: |
+          echo "::error::Unstaged changes detected - it is likely that the Elm Tailwind Modules need updating."
+          exit 1


### PR DESCRIPTION
This should cause the 'elm-tailwind-modules' workflow to fail if the modules are out of date.