### PR TITLE
Replace maybe-extra with core-extra

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -14,8 +14,8 @@
             "elm/json": "1.1.3",
             "elm/random": "1.0.0",
             "elm/url": "1.0.0",
-            "elm-community/maybe-extra": "5.3.0",
             "elm-community/random-extra": "3.2.0",
+            "elmcraft/core-extra": "2.0.0",
             "matheus23/elm-tailwind-modules-base": "1.0.0",
             "rtfeldman/elm-css": "16.1.1"
         },
@@ -23,6 +23,7 @@
             "danfishgold/base64-bytes": "1.1.0",
             "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
+            "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.3",
             "rtfeldman/elm-hex": "1.0.0"


### PR DESCRIPTION
Use [elmcraft/core-extra](https://github.com/elmcraft/core-extra/) instead of elm-community/maybe-extra.

Note: elm-community/random-extra is not covered in core-extra.